### PR TITLE
Disable the progress bar if input is not seekable

### DIFF
--- a/csv_writer.py
+++ b/csv_writer.py
@@ -28,7 +28,7 @@ class CSVConverter:
         self.output_format = output_format
         self.batch_size = batch_size
         self.hide_progress = hide_progress
-        self.progress = FileSizeProgressBar(infile, outfile, disable=hide_progress)
+        self.progress = FileSizeProgressBar(infile, outfile, disable=(hide_progress or not self.infile.seekable()))
 
     def _read_lines(self):
         """
@@ -44,7 +44,7 @@ class CSVConverter:
                 except Exception as ex:
                     self.converter.counts["parse_errors"] += 1
                     log.error(f"Error when trying to parse json: '{line}' {ex}")
-            if not self.hide_progress:
+            if not self.hide_progress and self.infile.seekable():
                 self.progress.update(self.infile.tell() - self.progress.n)
             line = self.infile.readline()
 


### PR DESCRIPTION
and avoid that reading from stdin fails with io.UnsupportedOperation exception.

The failure / exception is reproducible by running the second command:

```
$> twarc2 csv tweets.jsonl tweets.csv
100%|█████████████████████████████████████████| Processed 160M/160M of input file [00:25<00:00, 6.64MB/s]

ℹ️
Parsed 66130 tweets objects from 66130 lines in the input file.
Wrote 66130 rows and output 74 columns in the CSV.


$> cat tweets.jsonl | twarc2 csv >tweets.csv
Traceback (most recent call last):
  File ".../bin/twarc2", line 8, in <module>
    sys.exit(twarc2())
  ...
  File ".../lib/python3.10/site-packages/csv_writer.py", line 48, in _read_lines
    self.progress.update(self.infile.tell() - self.progress.n)
io.UnsupportedOperation: underlying stream is not seekable


# (no error without progress bar)
$> cat tweets.jsonl | twarc2 csv --hide-progress >tweets.csv
```